### PR TITLE
Games -> Game Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Twin Cities Tech Events
+
+View the list at [tctech.events](http://tctech.events/).
+
+Submit a pull request to contribute.
+
+

--- a/index.html
+++ b/index.html
@@ -78,11 +78,12 @@
 <li><a href="http://www.meetup.com/BehaviorMN/">BehaviorMN</a> <em>monthly</em> -- super popular meetup on behavior in tech</li>
 </ul>
 
-<h3>Games</h3>
+<h3>Game Development</h3>
 <ul>
-<li><a href="http://glitchcon.mn">GLITCH CON</a> <em>April</em> -- Minnesota's largest game conference</li>
-<li><a href="http://gamersrhapsody.com/">Gamers Rhapsody</a> <em>November</em> -- gaming and music</li>
-<li><a href="http://igdatc.org">IGDA</a> <em>monthly</em></li>
+<li><a href="http://glitchcon.mn">GLITCH CON</a> <em>April</em> -- Minnesota's only game development conference</li>
+<li><a href="http://gamersrhapsody.com/">Gamers Rhapsody</a> <em>November</em> -- a video game media (music) convention</li>
+<li><a href="http://igdatc.org/">IGDA Twin Cities</a> <em>monthly</em> -- general presentations on game industry topics</li>
+<li><a href="http://www.igdatc.org/mn-vr-and-hci/">MN VR &amp; HCI</a> <em>monthly</em> -- Virtual Reality, Human-Computer Interaction, hardware hacking, creative coding and interactive art</li>
 </ul>
 
 <h3>Security</h3>
@@ -140,7 +141,8 @@
 <li><a href="https://startupweekend.org/events?utf8=%E2%9C%93&q=Saint+Paul%2C+United+States&button=">Startup Weekend Twin Cities</a> <em>occasional</em> -- start a startup in 54 hours</li>
 <li><a href="http://www.up.co/communities/usa/twincities/startup-weekend/7442">Startup Weekend Education</a> <em>February</em> -- start a startup focused on education in 54 hours</li>
 <li><a href="http://minnehack.io/">Minnehack</a> <em>October</em> -- giant hackathon for college students</li>
-<li><a href="http://gamecraft.mn">Gamecraft</a> <em>January</em> -- 48-hour game hackathon</li>
+<li><a href="http://gamecraft.mn">Gamecraft</a> <em>January</em> -- Twin Cities site for the <a href="http://globalgamejam.org">Global Game Jam</a></li>
+<li><a href="http://midwestgamejam.org/">Midwest Game Jam</a> <em>November</em> -- 24-hour game jam</li>
 <li><a href="http://iotfuse.com">IOT FUSE Hack Day</a> <em>October</em> -- build an IOT device in 12 hours</li>
 <li><a href="http://iotfuse.com">IOT FUSE Mothers Day Makeathon</a> <em>May</em> -- build an IOT device in 12 hours</li>
 <li><a href="http://www.overnightwebsitechallenge.com/">Nerdery Overnight Website Challenge</a> <em>fall</em> -- make web sites for nonprofits in 24 hours</li>


### PR DESCRIPTION
A bunch of wording changes. In general, it's preferable to use "Game Development" rather than "Gaming", because there are actually a ton of "Gaming" events in the twin cities. (For example, GlitchCon is nowhere near the largest gaming convention locally. But it does happen to be the only game development convention.)

I also added the VR & HCI meetup as separate from IGDA Twin Cities (it is a rather incestuous crowd, but they are distinct in most ways), and the Midwest Game Jam.
