### PR TITLE
Updated details for NFJS

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@
 <ul>
 <li><a href="https://www.umsec.umn.edu/events/Code-Freeze-2016-Disruptive-Innovation">Code Freeze</a> <em>January</em></li>
 <li><a href="http://twincitiescodecamp.com">Code Camp</a> <em>April</em></li>
-<li><a href="https://nofluffjuststuff.com">No Fluff Just Stuff</a> <em>October</em> -- Java focused</li>
+<li><a href="https://nofluffjuststuff.com">No Fluff Just Stuff</a> <em>March and October</em> -- Java and JVM focused</li>
 <li><a href="https://notepadconf.com/">Notepad Conf</a> <em>almost never</em> </li>
 <li><a href="https://mdc.ilmservice.com/">Minnesota Developers Conference</a> <em>September</em></li>
 <li><a href="http://www.meetup.com/PyMNtos-Twin-Cities-Python-User-Group/">PyMNtos</a> <em>monthly</em> </li>


### PR DESCRIPTION
I've updated the months for NFJS (which happens both in the Spring and in the Fall), as well as a minor tweak to the description—the conference focuses more broadly across JVM languages and tech than just Java.
