### PR TITLE
add minnesota code championship

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,6 +145,7 @@
 <li><a href="https://codeday.org/minneapolis">Code Day</a> <em>May</em> -- nationwide student code event</li>
 <li><a href="http://technovationmn.org/events/2016-appapalooza-regional-competition/">Appapalooza</a> <em>May</em> -- girls make mobile apps</li>
 <li><a href="http://scimathmn.org/mnstemnet/">State Fair STEM Day</a> <em>August</em></li>
+<li><a href="https://www.codechampionship.com/">Minnesota Code Championship</a> <em>August</em> -- competitive computer coding</li>
 </ul>
 
 <h3>Hackathons</h3>


### PR DESCRIPTION
I hope I did this right! I linked to the homepage so that the link won't go out of date after the 2019 Minnesota Code Championship this August. If I should use this url instead, let me know!

https://www.codechampionship.com/minnesota-code-championship-2019/

Thank you!